### PR TITLE
ci: build and publish docker image to ghcr on main and version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Build and Publish Docker Image
+
+# Works today, with zero process changes required. Also future-proof: the tag-triggered part below is simply dormant until the repo has a "vX.Y.Z" tag.
+# No semantic-release or conventional commits needed, just create one whenever a version feels ready,
+# either with a plain `git tag v1.3.0 && git push origin v1.3.0`, or through the Releases UI (Draft a new release  -> e.g. v1.3.0 -> Publish),
+# which also pushes the tag under the hood as long as it didn't already exist.
+# Both paths trigger this workflow as-is, no edits to this file required.
+#
+# - push to main   -> :edge + :sha-<commit>   (never touches :latest)
+# - push of v*.*.* -> :X.Y.Z, :X.Y, :X, :latest
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*.*.*"]
+  workflow_dispatch: {}
+
+# Cancel superseded in-flight builds on main; never cancel tag builds mid-publish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_type == 'branch' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }} # -> ghcr.io/wilooper/lyrica
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=edge,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the Docker image and publishes it to GHCR (`ghcr.io/wilooper/lyrica`):

- push to `main` → `:edge` + `:sha-<commit>`
- push of a `v*.*.*` tag (or publishing a GitHub Release with a new tag) → `:X.Y.Z`, `:X.Y`, `:X`, `:latest`

No process change required: tagging stays fully manual (`git tag v1.0.0 && git push origin v1.0.0`, or the Releases UI). Superseded `main` builds are auto-cancelled; tag builds never are.

## Versioning (up to you)

Manual tags work fine as-is. If you later want automated releases from commit messages (à la semantic-release), the two usual picks are [release-please](https://github.com/googleapis/release-please) (language-agnostic, opens a release PR that tags on merge) or [python-semantic-release](https://python-semantic-release.readthedocs.io/) — both use conventional commits and would trigger this workflow untouched, since it only cares about `v*` tags.

## Make the package public (one-time)

After the first push, the GHCR package is private by default: GitHub profile → **Packages** → `lyrica` → **Package settings** → Danger Zone → **Change visibility** → Public. Then `docker pull ghcr.io/wilooper/lyrica:edge` works for everyone.