### PR TITLE
ci: build multi-arch docker images (amd64, arm64)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -60,6 +63,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Publishes images for `linux/amd64` and `linux/arm64` instead of amd64 only. pulls on Apple Silicon and other ARM hosts currently fail with `no matching manifest for linux/arm64/v8`.

- Add QEMU setup step so the runner can cross-build arm64
- Add `platforms: linux/amd64,linux/arm64` to the build step

Note: the arm64 leg builds under emulation, so expect noticeably longer CI runs. If it gets painful, the upgrade is per-arch jobs on native runners (`ubuntu-24.04-arm`) with a manifest merge. not worth the complexity until then.